### PR TITLE
Feature/seperate stylesheet

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,15 +1,6 @@
 
 //https://api.github.com/repos/tldr-pages/tldr/contents/pages/common
 let tldrURL = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-let fontURLBold = chrome.runtime.getURL('/fonts/OfficeCodePro-Bold.woff'),
-    fontURLMedium = chrome.runtime.getURL('/fonts/OfficeCodePro-Medium.woff'),
-    fontURLMediumItalic = chrome.runtime.getURL('/fonts/OfficeCodePro-MediumItalic.woff')
-
-document.createElement("style").innerText += ".TDLRmarkdown h1 {font-family: monospace; font-size: 40px; color: white; }\
-                                              .TDLRmarkdown code {background: white;}\
-                                              @font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLMedium + "') format('woff');}\
-                                              @font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLBold + "') format('woff'); font-weight: 900;}\
-                                              @font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLMediumItalic + "') format('woff'); font-style: italic}"
 var tooltip = null
 var arrow = null
 var currentContent = null
@@ -55,22 +46,14 @@ function createTooltip(content, isMarked) {
     }
 
     tooltip = document.createElement('div')
-    tooltip.id = "TLDRtooltip"
+    tooltip.id = "tldr-chrome"
     newtop = rect.top - 200 + window.scrollY
 
     Object.assign(
       tooltip.style,
       {
-        background: "#4A4A4A",
-        boxShadow: "0 2px 4px 0 rgba(0,0,0,0.50)",
-        borderRadius: "8px",
-        transition: '.2s',
-        position: "absolute",
-        overflow: "scroll",
         top: newtop + 'px',
         left: rect.left + 'px',
-        height: '195px',
-        width: '500px'
 
       }
     )
@@ -80,17 +63,12 @@ function createTooltip(content, isMarked) {
     // Create Arrow
 
     arrow = document.createElement('div')
+    arrow.id = "tldr-chrome-arrow"
     document.body.appendChild(arrow)
 
     Object.assign(
       arrow.style,
       {
-        width: "0",
-        height: "0",
-        borderLeft: "10px solid transparent",
-        borderRight: "10px solid transparent",
-        borderTop: "10px solid #4A4A4A",
-        position: "absolute",
         left: (rect.left) + 5 +'px',
         top: newtop + 195 + 'px' // newtop + height of tooltip
       }
@@ -111,84 +89,6 @@ function createTooltip(content, isMarked) {
     markdownContent.innerHTML = markdown
     markdownContent.className += 'TLDRmarkdown'
     tooltip.appendChild(markdownContent)
-
-    fontface = document.createElement('style')
-    document.head.appendChild(fontface)
-    fontface.innerText += "@font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLMedium + "') format('woff');}\
-    @font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLBold + "') format('woff'); font-weight: 900;}\
-    @font-face { font-family: 'Office Code Pro'; src:  url('" + fontURLMediumItalic + "') format('woff'); font-style: italic}\
-    "
-
-    Object.assign(
-      markdownContent.style,
-      {
-        color: "white",
-        padding: "10px"
-      }
-    )
-
-    Object.assign(
-      markdownContent.getElementsByTagName('h1')[0].style,
-      {
-        fontSize: '30px',
-        fontFamily: 'Office Code Pro',
-        color: 'white'
-      }
-    )
-
-    Object.assign(
-      markdownContent.getElementsByTagName('blockquote')[0].style,
-      {
-        fontSize: '15px',
-        fontFamily: 'Office Code Pro',
-        fontStyle: 'italic',
-        color: 'white'
-      }
-    )
-
-    for (i of markdownContent.getElementsByTagName('p')) {
-      Object.assign(
-        i.style,
-        {
-          fontSize: '15px',
-          fontFamily: 'Office Code Pro',
-          color: 'white'
-        }
-      )
-    }
-    for (i of markdownContent.getElementsByTagName('li')) {
-      Object.assign(
-        i.style,
-        {
-          fontSize: '14px',
-          fontFamily: 'Office Code Pro',
-          color: 'white',
-          listStyleType: 'none'
-
-        }
-      )
-    }
-    for (i of markdownContent.getElementsByTagName('ul')) {
-      Object.assign(
-        i.style,
-        {
-          marginLeft: '0',
-          paddingLeft: '0',
-        }
-      )
-    }
-    for (i of markdownContent.getElementsByTagName('code')) {
-      Object.assign(
-        i.style,
-        {
-          background: 'white',
-          borderRadius: '2px',
-          boxShadow: '0 1px 2px 0 rgba(0,0,0,0.50)',
-          color: '#4A4A4A'
-        }
-      )
-    }
-
   }
 
 }

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ function createTooltip(content, isMarked) {
 
     // Create markdown and append to tooltip
     if (content.trim() === "404: Not Found") {
-      var markdown = "<center><p style='font-size:50px;padding:0; padding-top: 30px; margin:0;'>😱</p><p>Page Not Found!</p><p>Submit a pull request to: <a target='_blank' href='https://github.com/tldr-pages/tldr'>https://github.com/tldr-pages/tldr</a></p>"
+      var markdown = "<div class='not-found'><p class='large'>😱</p><p>Page Not Found!</p><p>Submit a pull request to: <a target='_blank' href='https://github.com/tldr-pages/tldr'>https://github.com/tldr-pages/tldr</a></p>"
     } else if (isMarked) {
       var markdown = content
     } else {
@@ -87,7 +87,7 @@ function createTooltip(content, isMarked) {
 
     var markdownContent = document.createElement('div')
     markdownContent.innerHTML = markdown
-    markdownContent.className += 'TLDRmarkdown'
+    markdownContent.className += 'tldr-chrome'
     tooltip.appendChild(markdownContent)
   }
 

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ function createTooltip(content, isMarked) {
 
     // Create markdown and append to tooltip
     if (content.trim() === "404: Not Found") {
-      var markdown = "<div class='not-found'><p class='large'>😱</p><p>Page Not Found!</p><p>Submit a pull request to: <a target='_blank' href='https://github.com/tldr-pages/tldr'>https://github.com/tldr-pages/tldr</a></p>"
+      var markdown = "<div class='not-found'><p class='large'>😱</p><p>Page Not Found!</p><p>Submit a pull request to: <a target='_blank' href='https://github.com/tldr-pages/tldr'>https://github.com/tldr-pages/tldr</a></p></div>"
     } else if (isMarked) {
       var markdown = content
     } else {

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,9 @@
     "contextMenus",
     "tabs"
   ],
+  "web_accessible_resources": [
+    "fonts/*"
+  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -13,6 +13,9 @@
       "js": [
         "marked.js",
         "main.js"
+      ],
+      "css": [
+        "styles/main.css"
       ]
     }
   ],

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -20,6 +20,7 @@
 
 #tldr-chrome
 {
+    z-index: 1000;
     color: #ffffff;
     padding: 10px;
 
@@ -70,10 +71,21 @@
         font-style: italic;
         color: #ffffff;
     }
+    .not-found
+    {
+        text-align: center;
+        .large
+        {
+            font-size: 50px;
+            padding: 30px 0 0;
+            margin: 0;
+        }
+    }
 }
 
 #tldr-chrome-arrow
 {
+    z-index: 1000;
     width: 0;
     height: 0;
     border-left: 10px solid transparent;

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,20 +1,20 @@
 @font-face
 {
     font-family: 'Office Code Pro';
-    src: url('') format('woff');
+    src: url('chrome-extension://__MSG_@@extension_id__/fonts/OfficeCodePro-Medium.woff') format('woff');
 }
 
 @font-face
 {
     font-family: 'Office Code Pro';
-    src: url('') format('woff');
+    src: url('chrome-extension://__MSG_@@extension_id__/fonts/OfficeCodePro-Bold.woff') format('woff');
     font-weight: 900;
 }
 
 @font-face
 {
     font-family: 'Office Code Pro';
-    src: url('') format('woff');
+    src: url('chrome-extension://__MSG_@@extension_id__/fonts/OfficeCodePro-MediumItalic.woff') format('woff');
     font-style: italic
 }
 

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -79,7 +79,15 @@
     }
     .not-found
     {
-        text-align: center;
+        p
+        {
+            text-align: center;
+        }
+        a
+        {
+            cursor: pointer;
+            color: royalblue;
+        }
         .large
         {
             font-size: 50px;

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -20,8 +20,14 @@
 
 #tldr-chrome
 {
+    *
+    {
+        all: initial;
+        font-family: 'Office Code Pro', monospace;
+        color: #ffffff;
+    }
+
     z-index: 1000;
-    color: #ffffff;
     padding: 10px;
 
     background: #4A4A4A;
@@ -35,9 +41,12 @@
 
     code
     {
+        font-family: monospace;
+        font-size: 12px;
         background: white;
         border-radius: 2px;
         box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.50);
+        padding: 2px;
         color: #4A4A4A;
     }
     ul
@@ -47,29 +56,25 @@
     }
     li
     {
-        font-size: 14px;
-        font-family: 'Office Code Pro', monospace;
-        color: #ffffff;
+        font-size: 12px;
         list-style-type: none;
     }
     p
     {
+        margin-top: 0;
+        margin-bottom: 10px;
+        display: block;
         font-size: 15px;
-        font-family: 'Office Code Pro', monospace;
-        color: #ffffff;
     }
     h1
     {
         font-size: 30px;
-        font-family: 'Office Code Pro', monospace;
-        color: #ffffff;
+        font-weight: bold;
     }
-    blockquote
+    blockquote, blockquote p
     {
         font-size: 15px;
-        font-family: 'Office Code Pro', monospace;
         font-style: italic;
-        color: #ffffff;
     }
     .not-found
     {
@@ -85,6 +90,8 @@
 
 #tldr-chrome-arrow
 {
+    all: initial;
+
     z-index: 1000;
     width: 0;
     height: 0;

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -58,6 +58,7 @@
     {
         font-size: 12px;
         list-style-type: none;
+        line-height: 2;
     }
     p
     {

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -1,0 +1,83 @@
+@font-face
+{
+    font-family: 'Office Code Pro';
+    src: url('') format('woff');
+}
+
+@font-face
+{
+    font-family: 'Office Code Pro';
+    src: url('') format('woff');
+    font-weight: 900;
+}
+
+@font-face
+{
+    font-family: 'Office Code Pro';
+    src: url('') format('woff');
+    font-style: italic
+}
+
+#tldr-chrome
+{
+    color: #ffffff;
+    padding: 10px;
+
+    background: #4A4A4A;
+    box-shadow: 0 2px 4px;
+    border-radius: 8px;
+    transition: .2s;
+    position: absolute;
+    overflow: auto;
+    height: 195px;
+    width: 500px;
+
+    code
+    {
+        background: white;
+        border-radius: 2px;
+        box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.50);
+        color: #4A4A4A;
+    }
+    ul
+    {
+        margin-left: 0;
+        padding-left: 0;
+    }
+    li
+    {
+        font-size: 14px;
+        font-family: 'Office Code Pro', monospace;
+        color: #ffffff;
+        list-style-type: none;
+    }
+    p
+    {
+        font-size: 15px;
+        font-family: 'Office Code Pro', monospace;
+        color: #ffffff;
+    }
+    h1
+    {
+        font-size: 30px;
+        font-family: 'Office Code Pro', monospace;
+        color: #ffffff;
+    }
+    blockquote
+    {
+        font-size: 15px;
+        font-family: 'Office Code Pro', monospace;
+        font-style: italic;
+        color: #ffffff;
+    }
+}
+
+#tldr-chrome-arrow
+{
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-top: 10px solid #4A4A4A;
+    position: absolute;
+}

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -29,7 +29,7 @@
 
     z-index: 1000;
     padding: 10px;
-
+    box-sizing: border-box;
     background: #4A4A4A;
     box-shadow: 0 2px 4px;
     border-radius: 8px;


### PR DESCRIPTION
If applied, this PR will:
- Split out the stylesheet into a `styles/main.scss` file (see notes)
- Remove a lot of the styling from the JavaScript file
- Change the popup to not use styles inherited from the current site

This would also close #2.

-------------

As per [line 4](#diff-2ff0d41c889649ed414fe07e48b3db1dR4), [line 10](#diff-2ff0d41c889649ed414fe07e48b3db1dR10) and [line 17](#diff-2ff0d41c889649ed414fe07e48b3db1dR17), these currently use internal id generation for the package.

This is great for development, but not sure how reliable it is in production.

-------------

It currently looks like the following:

![Example](https://image.prntscr.com/image/LFRp3rJ4TuaiTnlVPOYiAw.png)

-------------

#### Notes

1. I haven't committed a `.css` file as it will probably change quite often.